### PR TITLE
cgo cross-compiling for Darwin

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,6 +12,7 @@
 builds:
   - binary: gotop
     goos:
+      - darwin
       - linux
     goarch:
       - amd64
@@ -27,3 +28,9 @@ archive:
   replacements:
     arm64: arm8
   format: tgz
+brew:
+  github:
+    owner: cjbassi
+    name: homebrew-gotop
+  description: "A terminal based graphical activity monitor inspired by gtop and vtop"
+  homepage: "https://github.com/cjbassi/gotop"

--- a/download.sh
+++ b/download.sh
@@ -12,6 +12,8 @@ download() {
 arch=$(uname -sm)
 case "$arch" in
     # order matters
+    Darwin\ *64)        download darwin_amd64   ;;
+    Darwin\ *86)        download darwin_386     ;;
     Linux\ armv5*)      download linux_arm5     ;;
     Linux\ armv6*)      download linux_arm6     ;;
     Linux\ armv7*)      download linux_arm7     ;;

--- a/main.go
+++ b/main.go
@@ -194,29 +194,29 @@ func initWidgets() {
 	wg.Add(widgetCount)
 
 	go func() {
-		defer wg.Done()
 		cpu = w.NewCPU(interval, zoom)
+		wg.Done()
 	}()
 	go func() {
-		defer wg.Done()
 		mem = w.NewMem(interval, zoom)
+		wg.Done()
 	}()
 	go func() {
-		defer wg.Done()
 		proc = w.NewProc(keyPressed)
+		wg.Done()
 	}()
 	if !minimal {
 		go func() {
-			defer wg.Done()
 			net = w.NewNet()
+			wg.Done()
 		}()
 		go func() {
-			defer wg.Done()
 			disk = w.NewDisk()
+			wg.Done()
 		}()
 		go func() {
-			defer wg.Done()
 			temp = w.NewTemp()
+			wg.Done()
 		}()
 	}
 


### PR DESCRIPTION
Relates to (but does not close): #27. Fixes #9.

Restored the Darwin builds & releases. Enabled cross-compiling of `cgo` via [xgo](https://github.com/karalabe/xgo).

See example release here: https://github.com/f1337/gotop/releases/tag/1.2.15

The solution is somewhat hacky, as it expects `goreleaser` to build Darwin binaries, then re-builds and overwrites them using `xgo`. Why? So that `goreleaser` will publish the re-built binaries to github/homebrew/etc.