### PR TITLE
Remove 8 cores limit in CPU widget

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,6 +37,9 @@ var (
 	zoom         = 7
 	zoomInterval = 3
 
+	averageLoad = true
+	percpuLoad = true
+
 	cpu  *w.CPU
 	mem  *w.Mem
 	proc *w.Proc
@@ -173,15 +176,16 @@ func widgetColors() {
 	mem.LineColor["Main"] = ui.Color(colorscheme.MainMem)
 	mem.LineColor["Swap"] = ui.Color(colorscheme.SwapMem)
 
-	LineColor := make(map[string]ui.Color)
-	if cpu.Count <= 8 {
-		for i := 0; i < len(cpu.Data); i++ {
-			LineColor[fmt.Sprintf("CPU%d", i)] = ui.Color(colorscheme.CPULines[i])
+	i := 0
+	for k := range cpu.Data {
+		if i >= len(colorscheme.CPULines) {
+			// assuming colorscheme for CPU lines is not empty
+			i = 0
 		}
-	} else {
-		LineColor["Average"] = ui.Color(colorscheme.CPULines[0])
+		c := colorscheme.CPULines[i]
+		cpu.LineColor[k] = ui.Color(c)
+		i++
 	}
-	cpu.LineColor = LineColor
 
 	if !minimal {
 		temp.TempLow = ui.Color(colorscheme.TempLow)
@@ -194,7 +198,7 @@ func initWidgets() {
 	wg.Add(widgetCount)
 
 	go func() {
-		cpu = w.NewCPU(interval, zoom)
+		cpu = w.NewCPU(interval, zoom, averageLoad, percpuLoad)
 		wg.Done()
 	}()
 	go func() {

--- a/main.go
+++ b/main.go
@@ -37,8 +37,8 @@ var (
 	zoom         = 7
 	zoomInterval = 3
 
-	averageLoad = true
-	percpuLoad = true
+	averageLoad = false
+	percpuLoad = false
 
 	cpu  *w.CPU
 	mem  *w.Mem

--- a/src/widgets/cpu.go
+++ b/src/widgets/cpu.go
@@ -28,6 +28,14 @@ func NewCPU(interval time.Duration, zoom int, average bool, percpu bool) *CPU {
 	self.Label = "CPU Usage"
 	self.Zoom = zoom
 
+	if !(self.Average || self.PerCPU) {
+		if self.Count <= 8 {
+			self.PerCPU = true
+		} else {
+			self.Average = true
+		}
+	}
+
 	if self.Average {
 		self.Data["Average"] = []float64{0}
 	}

--- a/src/widgets/cpu.go
+++ b/src/widgets/cpu.go
@@ -2,10 +2,8 @@ package widgets
 
 import (
 	"fmt"
-	"strconv"
 	"time"
 
-	"github.com/cjbassi/gotop/src/utils"
 	ui "github.com/cjbassi/termui"
 	psCPU "github.com/shirou/gopsutil/cpu"
 )
@@ -13,32 +11,37 @@ import (
 type CPU struct {
 	*ui.LineGraph
 	Count    int // number of cores
+	Average bool // show average load
+	PerCPU bool // show per-core load
 	interval time.Duration
 }
 
-func NewCPU(interval time.Duration, zoom int) *CPU {
+func NewCPU(interval time.Duration, zoom int, average bool, percpu bool) *CPU {
 	count, _ := psCPU.Counts(false)
 	self := &CPU{
 		LineGraph: ui.NewLineGraph(),
 		Count:     count,
 		interval:  interval,
+		Average:   average,
+		PerCPU:    percpu,
 	}
 	self.Label = "CPU Usage"
 	self.Zoom = zoom
-	if self.Count <= 8 {
-		for i := 0; i < self.Count; i++ {
-			key := "CPU" + strconv.Itoa(i)
-			self.Data[key] = []float64{0}
-		}
-	} else {
+
+	if self.Average {
 		self.Data["Average"] = []float64{0}
 	}
 
-	// update asynchronously because of 1 second blocking period
-	go self.update()
+	if self.PerCPU {
+		for i := 0; i < self.Count; i++ {
+			k := fmt.Sprintf("CPU%d", i)
+			self.Data[k] = []float64{0}
+		}
+	}
 
 	ticker := time.NewTicker(self.interval)
 	go func() {
+		self.update()
 		for range ticker.C {
 			self.update()
 		}
@@ -49,29 +52,18 @@ func NewCPU(interval time.Duration, zoom int) *CPU {
 
 // calculates the CPU usage over a 1 second interval and blocks for the duration
 func (self *CPU) update() {
-	// show average cpu usage if more than 8 cores
-	if self.Count <= 8 {
-		percents, _ := psCPU.Percent(self.interval, true)
-		if len(percents) != self.Count {
-			count, _ := psCPU.Counts(false)
-			utils.Error("CPU percentages",
-				fmt.Sprint(
-					"self.Count: ", self.Count, "\n",
-					"gopsutil.Counts(): ", count, "\n",
-					"len(percents): ", len(percents), "\n",
-					"percents: ", percents, "\n",
-					"self.interval: ", self.interval,
-				))
-		}
-		for i := 0; i < self.Count; i++ {
-			key := "CPU" + strconv.Itoa(i)
-			percent := percents[i]
-			self.Data[key] = append(self.Data[key], percent)
-			self.Labels[key] = fmt.Sprintf("%3.0f%%", percent)
-		}
-	} else {
+	if self.Average {
 		percent, _ := psCPU.Percent(self.interval, false)
 		self.Data["Average"] = append(self.Data["Average"], percent[0])
 		self.Labels["Average"] = fmt.Sprintf("%3.0f%%", percent[0])
+	}
+
+	if self.PerCPU {
+		percents, _ := psCPU.Percent(self.interval, true)
+		for i := 0; i < self.Count; i++ {
+			k := fmt.Sprintf("CPU%d", i)
+			self.Data[k] = append(self.Data[k], percents[i])
+			self.Labels[k] = fmt.Sprintf("%3.0f%%", percents[i])
+		}
 	}
 }


### PR DESCRIPTION
This PR removes stupid 8 cores limit in CPU widget and makes load stats a little bit more configurable.  *Both* per-CPU and average load stats are now optional and aren't exclusive.  If none of those options are set, CPU widget falls back to the old behavior.

It should be trivial to add command line option with three possible values (`percpu`, `average`, `both`), but I can't come up with a name for such option.