### PR TITLE
OpenBSD support

### DIFF
--- a/src/widgets/proc_other.go
+++ b/src/widgets/proc_other.go
@@ -1,4 +1,4 @@
-// +build freebsd darwin
+// +build freebsd darwin openbsd
 
 package widgets
 

--- a/src/widgets/temp_openbsd.go
+++ b/src/widgets/temp_openbsd.go
@@ -6,9 +6,9 @@ package widgets
 import "C"
 
 import (
-	"unsafe"
-	"syscall"
 	"strconv"
+	"syscall"
+	"unsafe"
 
 	"github.com/cjbassi/gotop/src/utils"
 )
@@ -17,7 +17,7 @@ func gettemp(t *Temp, mib []C.int, mlen int, snsrdev *C.struct_sensordev, index 
 	if mlen == 4 {
 		k := mib[3]
 		var numt C.int
-		for numt = 0; numt < snsrdev.maxnumt[k]; numt += 1 {
+		for numt = 0; numt < snsrdev.maxnumt[k]; numt++ {
 			mib[4] = numt
 			gettemp(t, mib, mlen+1, snsrdev, int(numt))
 		}
@@ -32,7 +32,7 @@ func gettemp(t *Temp, mib []C.int, mlen int, snsrdev *C.struct_sensordev, index 
 			return
 		}
 
-		if slen > 0 && (snsr.flags & C.SENSOR_FINVALID) == 0 {
+		if slen > 0 && (snsr.flags&C.SENSOR_FINVALID) == 0 {
 			key := C.GoString(&snsrdev.xname[0]) + ".temp" + strconv.Itoa(index)
 			temp := int((snsr.value - 273150000.0) / 1000000.0)
 
@@ -58,7 +58,7 @@ func (self *Temp) update() {
 	mib[3] = C.SENSOR_TEMP
 
 	var i C.int
-	for i = 0; ; i += 1 {
+	for i = 0; ; i++ {
 		mib[2] = i
 
 		if v, e := C.sysctl(&mib[0], 3, unsafe.Pointer(&snsrdev), &len, nil, 0); v == -1 {
@@ -67,7 +67,7 @@ func (self *Temp) update() {
 			}
 
 			if e == syscall.ENOENT {
-				break;
+				break
 			}
 		}
 

--- a/src/widgets/temp_openbsd.go
+++ b/src/widgets/temp_openbsd.go
@@ -1,0 +1,76 @@
+package widgets
+
+// #include <sys/time.h>
+// #include <sys/sysctl.h>
+// #include <sys/sensors.h>
+import "C"
+
+import (
+	"unsafe"
+	"syscall"
+	"strconv"
+
+	"github.com/cjbassi/gotop/src/utils"
+)
+
+func gettemp(t *Temp, mib []C.int, mlen int, snsrdev *C.struct_sensordev, index int) {
+	if mlen == 4 {
+		k := mib[3]
+		var numt C.int
+		for numt = 0; numt < snsrdev.maxnumt[k]; numt += 1 {
+			mib[4] = numt
+			gettemp(t, mib, mlen+1, snsrdev, int(numt))
+		}
+		return
+	}
+
+	if mlen == 5 {
+		var snsr C.struct_sensor
+		var slen C.size_t = C.sizeof_struct_sensor
+
+		if v, _ := C.sysctl(&mib[0], 5, unsafe.Pointer(&snsr), &slen, nil, 0); v == -1 {
+			return
+		}
+
+		if slen > 0 && (snsr.flags & C.SENSOR_FINVALID) == 0 {
+			key := C.GoString(&snsrdev.xname[0]) + ".temp" + strconv.Itoa(index)
+			temp := int((snsr.value - 273150000.0) / 1000000.0)
+
+			if t.Fahrenheit {
+				t.Data[key] = utils.CelsiusToFahrenheit(temp)
+			} else {
+				t.Data[key] = temp
+			}
+		}
+
+		return
+	}
+}
+
+func (self *Temp) update() {
+	mib := []C.int{0, 1, 2, 3, 4}
+
+	var snsrdev C.struct_sensordev
+	var len C.ulong = C.sizeof_struct_sensordev
+
+	mib[0] = C.CTL_HW
+	mib[1] = C.HW_SENSORS
+	mib[3] = C.SENSOR_TEMP
+
+	var i C.int
+	for i = 0; ; i += 1 {
+		mib[2] = i
+
+		if v, e := C.sysctl(&mib[0], 3, unsafe.Pointer(&snsrdev), &len, nil, 0); v == -1 {
+			if e == syscall.ENXIO {
+				continue
+			}
+
+			if e == syscall.ENOENT {
+				break;
+			}
+		}
+
+		gettemp(self, mib, 4, &snsrdev, 0)
+	}
+}

--- a/src/widgets/temp_openbsd.go
+++ b/src/widgets/temp_openbsd.go
@@ -13,18 +13,16 @@ import (
 	"github.com/cjbassi/gotop/src/utils"
 )
 
-func gettemp(t *Temp, mib []C.int, mlen int, snsrdev *C.struct_sensordev, index int) {
-	if mlen == 4 {
+func getTemp(t *Temp, mib []C.int, mlen int, snsrdev *C.struct_sensordev, index int) {
+	switch mlen {
+	case 4:
 		k := mib[3]
 		var numt C.int
 		for numt = 0; numt < snsrdev.maxnumt[k]; numt++ {
 			mib[4] = numt
-			gettemp(t, mib, mlen+1, snsrdev, int(numt))
+			getTemp(t, mib, mlen+1, snsrdev, int(numt))
 		}
-		return
-	}
-
-	if mlen == 5 {
+	case 5:
 		var snsr C.struct_sensor
 		var slen C.size_t = C.sizeof_struct_sensor
 
@@ -42,8 +40,6 @@ func gettemp(t *Temp, mib []C.int, mlen int, snsrdev *C.struct_sensordev, index 
 				t.Data[key] = temp
 			}
 		}
-
-		return
 	}
 }
 
@@ -71,6 +67,6 @@ func (self *Temp) update() {
 			}
 		}
 
-		gettemp(self, mib, 4, &snsrdev, 0)
+		getTemp(self, mib, 4, &snsrdev, 0)
 	}
 }


### PR DESCRIPTION
Hi!

This adds `openbsd` to `proc_other` build tags (needed to build gotop and to get the list of processes) and implements `update` for Temp (loosely based on [`sysctl`(8) code](https://github.com/openbsd/src/blob/master/sbin/sysctl/sysctl.c#L2517)). With these changes `gotop` builds and runs on OpenBSD-CURRENT on amd64.

The disk, memory and network usage widgets worked OOTB, while the cpu usage displays wrong percentages (almost always 100% on all CPUs). Battery also doesn't seem to work, but I'll look into that.

It's the first time I write go code, I hope it doesn't suck too much.

Demonstrative screenshot:
![2019-02-18-113045_1105x667_scrot](https://user-images.githubusercontent.com/47739920/52944944-ed2cca00-3370-11e9-9c35-0deb9d8207fe.png)
