### PR TITLE
Add vice colorscheme based on vim-vice

### DIFF
--- a/colorschemes/vice.go
+++ b/colorschemes/vice.go
@@ -1,0 +1,25 @@
+package colorschemes
+
+var Vice = Colorscheme{
+	Fg: 231,
+	Bg: -1,
+
+	BorderLabel: 123,
+	BorderLine:  102,
+
+	CPULines: []int{212, 218, 123, 159, 229, 158, 183, 146},
+
+	BattLines: []int{212, 218, 123, 159, 229, 158, 183, 146},
+
+	MainMem: 201,
+	SwapMem: 97,
+
+	ProcCursor: 159,
+
+	Sparkline: 183,
+
+	DiskBar: 158,
+
+	TempLow:  49,
+	TempHigh: 197,
+}

--- a/main.go
+++ b/main.go
@@ -83,6 +83,7 @@ Colorschemes:
   default-dark (for white background)
   solarized
   monokai
+  vice
 `
 
 	args, err := docopt.ParseArgs(usage, os.Args[1:], version)
@@ -126,6 +127,8 @@ func handleColorscheme(cs string) error {
 		colorscheme = colorschemes.Solarized
 	case "monokai":
 		colorscheme = colorschemes.Monokai
+	case "vice":
+		colorscheme = colorschemes.Vice
 	case "default-dark":
 		colorscheme = colorschemes.DefaultDark
 	default:


### PR DESCRIPTION
This colorscheme is based off of [vim-vice](https://github.com/bcicen/vim-vice)

![screenshot-20190221024948-1720x1413](https://user-images.githubusercontent.com/14058972/53152625-0ce80c00-3584-11e9-8fbf-5aac8523adc5.png)

