### PR TITLE
Fix disk IO stats

### DIFF
--- a/src/widgets/disk.go
+++ b/src/widgets/disk.go
@@ -116,7 +116,7 @@ func (self *Disk) update() {
 			log.Printf("failed to get partition read/write info from gopsutil: %v. Part: %v", err, Part)
 			continue
 		}
-		data := ret[Part.Device]
+		data := ret[strings.Replace(Part.Device, "/dev/", "", -1)]
 		curRead, curWrite := data.ReadBytes, data.WriteBytes
 		if Part.TotalRead != 0 { // if this isn't the first update
 			readRecent := curRead - Part.TotalRead


### PR DESCRIPTION
`psDisk.IOCounters` returns devices with `/dev/` stripped but `Part.Device` is the full path, so it needs to be stripped when getting devices from the map.

Fixes #114
