### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/src/termui/drawille-go/drawille.go
+++ b/src/termui/drawille-go/drawille.go
@@ -143,17 +143,17 @@ func (c Canvas) Get(x, y int) bool {
 	return (char & dot_index) != 0
 }
 
-// Get character at the given screen coordinates
+// GetScreenCharacter gets character at the given screen coordinates
 func (c Canvas) GetScreenCharacter(x, y int) rune {
 	return rune(c.chars[y][x] + braille_char_offset)
 }
 
-// Get character for the given pixel
+// GetCharacter gets character for the given pixel
 func (c Canvas) GetCharacter(x, y int) rune {
 	return c.GetScreenCharacter(x/4, y/4)
 }
 
-// Retrieve the rows from a given view
+// Rows retrieves the rows from a given view
 func (c Canvas) Rows(minX, minY, maxX, maxY int) []string {
 	minrow, maxrow := minY/4, (maxY)/4
 	mincol, maxcol := minX/2, (maxX)/2
@@ -170,7 +170,7 @@ func (c Canvas) Rows(minX, minY, maxX, maxY int) []string {
 	return ret
 }
 
-// Retrieve a string representation of the frame at the given parameters
+// Frame retrieves a string representation of the frame at the given parameters
 func (c Canvas) Frame(minX, minY, maxX, maxY int) string {
 	var ret string
 	for _, row := range c.Rows(minX, minY, maxX, maxY) {


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?