### PR TITLE
Complete the refactor

### DIFF
--- a/src/widgets/proc_other.go
+++ b/src/widgets/proc_other.go
@@ -17,25 +17,7 @@ const (
 	fifty = ten + ten + ten + ten + ten
 )
 
-func (self *ProcWidget) update() {
-	procs, err := GetProcs()
-	if err != nil {
-		log.Printf("failed to retrieve processes: %v", err)
-		return
-	}
-
-	// have to iterate like this in order to actually change the value
-	for i := range procs {
-		procs[i].CPU /= self.cpuCount
-	}
-
-	self.ungroupedProcs = procs
-	self.groupedProcs = GroupProcs(procs)
-
-	self.SortProcesses()
-}
-
-func GetProcs() ([]Process, error) {
+func getProcs() ([]Proc, error) {
 	keywords := fmt.Sprintf("pid=%s,comm=%s,pcpu=%s,pmem=%s,args", ten, fifty, five, five)
 	output, err := exec.Command("ps", "-caxo", keywords).Output()
 	if err != nil {
@@ -60,11 +42,11 @@ func GetProcs() ([]Process, error) {
 			log.Printf("failed to convert fourth field to float: %v. split: %v", err, line)
 		}
 		proc := Proc{
-			PID:     pid,
-			Command: strings.TrimSpace(line[11:61]),
-			CPU:     cpu,
-			Mem:     mem,
-			Args:    line[74:],
+			Pid:         pid,
+			CommandName: strings.TrimSpace(line[11:61]),
+			Cpu:         cpu,
+			Mem:         mem,
+			FullCommand: line[74:],
 		}
 		procs = append(procs, proc)
 	}


### PR DESCRIPTION
I've noticed today that gotop doesn't compile on OpenBSD (and I suppose also on FreeBSD and Mac, but I cannot test). After a quick git blame this seems to be a consequence of 71e10bb6bea0db41a004a600202ed9e214595f68.

This pr is a simple rename of the proc field and the removal of `update` from `ProcWidget`.

Sorry for the poor commit message, I haven't come up with something more meaningful than that.