### PR TITLE
re-render statusbar on every tick

### DIFF
--- a/main.go
+++ b/main.go
@@ -288,6 +288,9 @@ func eventLoop() {
 		case <-drawTicker:
 			if !helpVisible {
 				ui.Render(grid)
+				if statusbar {
+					ui.Render(bar)
+				}
 			}
 		case e := <-uiEvents:
 			switch e.ID {


### PR DESCRIPTION
Hi,

The clock widget on the statusbar is updated only when resizing, I don't know if it's wanted or not. This commit re-render the whole statusbar on every tick.

Another option would be to change `setupGrid` to include the statusbar in the grid so we can remove various `if statusbar`.