### PR TITLE
Fix "TX" being displayed as "Tx"

### DIFF
--- a/src/widgets/net.go
+++ b/src/widgets/net.go
@@ -96,7 +96,7 @@ func (self *NetWidget) update() {
 			if i == 0 {
 				return totalBytesRecv, "RX", recentBytesRecv
 			}
-			return totalBytesSent, "Tx", recentBytesSent
+			return totalBytesSent, "TX", recentBytesSent
 		}()
 
 		recentConverted, unitRecent := utils.ConvertBytes(uint64(recent))


### PR DESCRIPTION
"RX" is all caps so either "TX" should also be or none. All caps might be the most common form for both.