### PR TITLE
Add a scroll location indicator to the process table

### DIFF
--- a/src/termui/table.go
+++ b/src/termui/table.go
@@ -1,6 +1,7 @@
 package termui
 
 import (
+	"fmt"
 	"image"
 	"log"
 	"strings"
@@ -20,6 +21,8 @@ type Table struct {
 
 	ShowCursor  bool
 	CursorColor Color
+
+	ShowLocation bool
 
 	UniqueCol    int    // the column used to uniquely identify each table row
 	SelectedItem string // used to keep the cursor on the correct item if the data changes
@@ -42,6 +45,10 @@ func NewTable() *Table {
 
 func (self *Table) Draw(buf *Buffer) {
 	self.Block.Draw(buf)
+
+	if self.ShowLocation {
+		self.drawLocation(buf)
+	}
 
 	self.ColResizer()
 
@@ -119,6 +126,21 @@ func (self *Table) Draw(buf *Buffer) {
 			)
 		}
 	}
+}
+
+// drawLoca
+func (self *Table) drawLocation(buf *Buffer) {
+	total := len(self.Rows)
+	topRow := self.TopRow + 1
+	bottomRow := self.TopRow + self.Inner.Dy() - 1
+	if bottomRow > total {
+		bottomRow = total
+	}
+
+	loc := fmt.Sprintf(" %d - %d of %d ", topRow, bottomRow, total)
+
+	width := len(loc)
+	buf.SetString(loc, self.TitleStyle, image.Pt(self.Max.X-width-2, self.Min.Y))
 }
 
 // Scrolling ///////////////////////////////////////////////////////////////////

--- a/src/termui/table.go
+++ b/src/termui/table.go
@@ -128,7 +128,6 @@ func (self *Table) Draw(buf *Buffer) {
 	}
 }
 
-// drawLoca
 func (self *Table) drawLocation(buf *Buffer) {
 	total := len(self.Rows)
 	topRow := self.TopRow + 1

--- a/src/widgets/proc.go
+++ b/src/widgets/proc.go
@@ -59,6 +59,7 @@ func NewProcWidget() *ProcWidget {
 	}
 	self.Title = " Processes "
 	self.ShowCursor = true
+	self.ShowLocation = true
 	self.ColGap = 3
 	self.PadLeft = 2
 	self.ColResizer = func() {


### PR DESCRIPTION
Implements #127 

I found that using `[selected] of [total]` wasn't effective because the selected row doesn't necessarily stay in the window. Instead I went with `[top of window] - [bottom of window] of [total]`. The values are 1-indexed.

I'm totally open to feedback or requests!

Here's an example:
![image](https://user-images.githubusercontent.com/5279257/54855847-4e2c2280-4cce-11e9-8fbc-a38011b9885a.png)
