### PR TITLE
FreeBSD process support

### DIFF
--- a/src/widgets/proc_freebsd.go
+++ b/src/widgets/proc_freebsd.go
@@ -1,0 +1,66 @@
+// +build freebsd
+
+package widgets
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type Keywords struct {
+	ProcessInformation struct {
+		Process []struct {
+			Pid  string `json: pid`
+			Comm string `json: command`
+			Cpu  string `json: percent-cpu`
+			Mem  string `json: percent-memory`
+			Args string `json: arguments`
+		} `json: process`
+	} `json: process-information`
+}
+
+func getProcs() ([]Proc, error) {
+	output, err := exec.Command("ps", "-axo pid,comm,%cpu,%mem,args", "--libxo", "json").Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute 'ps' command: %v", err)
+	}
+
+	processList := Keywords{}
+	err = json.Unmarshal(output, &processList)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal json. %s", err)
+	} else {
+		return nil, fmt.Errorf("Success to unmarshal json. %s", output)
+	}
+
+	procs := []Proc{}
+
+	for _, process := range processList.ProcessInformation.Process {
+		pid, err := strconv.Atoi(strings.TrimSpace(process.Pid))
+		if err != nil {
+			log.Printf("failed to convert first field to int: %v. split: %v", err, process)
+		}
+		cpu, err := strconv.ParseFloat(process.Cpu, 64)
+		if err != nil {
+			log.Printf("failed to convert third field to float: %v. split: %v", err, process)
+		}
+		mem, err := strconv.ParseFloat(process.Mem, 64)
+		if err != nil {
+			log.Printf("failed to convert fourth field to float: %v. split: %v", err, process)
+		}
+		proc := Proc{
+			Pid:         pid,
+			CommandName: process.Comm,
+			Cpu:         cpu,
+			Mem:         mem,
+			FullCommand: process.Args,
+		}
+		procs = append(procs, proc)
+	}
+
+	return procs, nil
+}

--- a/src/widgets/proc_freebsd.go
+++ b/src/widgets/proc_freebsd.go
@@ -11,16 +11,16 @@ import (
 	"strings"
 )
 
-type Keywords struct {
+type processList struct {
 	ProcessInformation struct {
 		Process []struct {
-			Pid  string `json: pid`
-			Comm string `json: command`
-			Cpu  string `json: percent-cpu`
-			Mem  string `json: percent-memory`
-			Args string `json: arguments`
-		} `json: process`
-	} `json: process-information`
+			Pid  string `json:"pid"`
+			Comm string `json:"command"`
+			Cpu  string `json:"percent-cpu" `
+			Mem  string `json:"percent-memory" `
+			Args string `json:"arguments" `
+		} `json:"process"`
+	} `json:"process-information"`
 }
 
 func getProcs() ([]Proc, error) {
@@ -29,17 +29,17 @@ func getProcs() ([]Proc, error) {
 		return nil, fmt.Errorf("failed to execute 'ps' command: %v", err)
 	}
 
-	processList := Keywords{}
-	err = json.Unmarshal(output, &processList)
+	list := processList{}
+	err = json.Unmarshal(output, &list)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal json. %s", err)
-	} else {
-		return nil, fmt.Errorf("Success to unmarshal json. %s", output)
 	}
-
 	procs := []Proc{}
 
-	for _, process := range processList.ProcessInformation.Process {
+	for _, process := range list.ProcessInformation.Process {
+		if process.Comm == "idle" {
+			continue
+		}
 		pid, err := strconv.Atoi(strings.TrimSpace(process.Pid))
 		if err != nil {
 			log.Printf("failed to convert first field to int: %v. split: %v", err, process)

--- a/src/widgets/proc_other.go
+++ b/src/widgets/proc_other.go
@@ -1,4 +1,4 @@
-// +build freebsd darwin openbsd
+// +build darwin openbsd
 
 package widgets
 


### PR DESCRIPTION
Leverage FreeBSD's json output capabilities.
With this the hardcoded string split is no longer necessary.