### PR TITLE
FreeBSD Fixes & Nvidia GPU Support

### DIFF
--- a/src/widgets/mem_freebsd.go
+++ b/src/widgets/mem_freebsd.go
@@ -42,7 +42,10 @@ func gatherSwapInfo() (MemoryInfo, error) {
 		}
 	}
 
-	ss := strings.Split(strings.TrimSuffix(string(output), "\n"), " ")
+	s := strings.TrimSuffix(string(output), "\n")
+	s = strings.ReplaceAll(s, "\n", " ")
+	ss := strings.Split(s, " ")
+	ss = ss[((len(ss)/3)-1)*3:]
 
 	return convert(ss)
 }

--- a/src/widgets/temp_freebsd.go
+++ b/src/widgets/temp_freebsd.go
@@ -1,12 +1,12 @@
 package widgets
 
 import (
-	"log"
 	"os/exec"
 	"strconv"
 	"strings"
 
 	"github.com/cjbassi/gotop/src/utils"
+	"github.com/rai-project/nvidia-smi"
 )
 
 var sensorOIDS = map[string]string{
@@ -34,7 +34,7 @@ func refineOutput(output []byte) (float64, error) {
 	return value, nil
 }
 
-func collectSensors() ([]sensorMeasurement, error) {
+func collectSysctlSensors() []sensorMeasurement {
 	var measurements []sensorMeasurement
 	for k, v := range sensorOIDS {
 		output, err := exec.Command("sysctl", "-n", k).Output()
@@ -50,15 +50,67 @@ func collectSensors() ([]sensorMeasurement, error) {
 		measurements = append(measurements, sensorMeasurement{v, value})
 	}
 
-	return measurements, nil
+	return measurements
+}
+
+func collectNvidiaSensors() []sensorMeasurement {
+	var measurements []sensorMeasurement
+
+	info, _ := nvidiasmi.New()
+	if info.HasGPU() {
+		for i := range info.GPUS {
+			gpu := info.GPUS[i]
+			var s sensorMeasurement
+			s.name = strings.ReplaceAll(strings.ToLower(gpu.ProductName), " ", "_") + "_" + strconv.Itoa(i) + "_input"
+			s.temperature, _ = strconv.ParseFloat(strings.ReplaceAll(gpu.GpuTemp, " C", ""), 10)
+			measurements = append(measurements, s)
+		}
+	}
+
+	return measurements
+}
+
+func collectAMDGPUSensors() []sensorMeasurement {
+	var measurments []sensorMeasurement
+
+	return measurments
+}
+
+func collectGPUSensors() []sensorMeasurement {
+	var measurements []sensorMeasurement
+
+	measurements = append(measurements, collectSysctlSensors()...)
+	measurements = append(measurements, collectNvidiaSensors()...)
+	measurements = append(measurements, collectAMDGPUSensors()...)
+
+	return measurements
+}
+
+func collectSensors() []sensorMeasurement {
+	var measurements []sensorMeasurement
+	for k, v := range sensorOIDS {
+		output, err := exec.Command("sysctl", "-n", k).Output()
+		if err != nil {
+			continue
+		}
+
+		value, err := refineOutput(output)
+		if err != nil {
+			continue
+		}
+
+		measurements = append(measurements, sensorMeasurement{v, value})
+	}
+
+	measurements = append(measurements, collectGPUSensors()...)
+
+	return measurements
 
 }
 
 func (self *TempWidget) update() {
-	sensors, err := collectSensors()
-	if err != nil {
-		log.Printf("error recieved from gopsutil: %v", err)
-	}
+	sensors := collectSensors()
+
 	for _, sensor := range sensors {
 		switch self.TempScale {
 		case Fahrenheit:

--- a/src/widgets/temp_freebsd.go
+++ b/src/widgets/temp_freebsd.go
@@ -35,22 +35,60 @@ func refineOutput(output []byte) (float64, error) {
 	return value, nil
 }
 
+func collectNvidiaGPUSensors() []sensorMeasurement {
+	var measurements []sensorMeasurement
+
+	_, err := exec.Command("sysctl", "-n", "hw.nvidia.gpus.0.model").Output()
+	if err == nil {
+		output, err := exec.Command("nvidia-settings", "-q", "gpucoretemp", "-t").Output()
+		if err != nil {
+			log.Printf("Failed to get nvidia gpu temperature from nvidia-settings")
+		} else {
+			s := strings.TrimSuffix(string(output), "\n")
+			s = strings.ReplaceAll(s, "\n", " ")
+			ss := strings.Split(s, " ")
+			for i := 1; i < len(ss); i++ {
+				value, err := refineOutput([]byte(ss[i]))
+				if err != nil {
+					log.Printf("Failed to parse nvidia-settings output")
+				}
+				label := fmt.Sprintf("Nvidia GPU %d", i-1)
+				measurements = append(measurements, sensorMeasurement{label, value})
+			}
+		}
+	}
+
+	return measurements
+}
+
+func collectGPUSensors() []sensorMeasurement {
+	var measurements []sensorMeasurement
+
+	m := collectNvidiaGPUSensors()
+	measurements = append(measurements, m...)
+
+	return measurements
+}
+
 func collectSensors() ([]sensorMeasurement, error) {
 	var measurements []sensorMeasurement
 	for k, v := range sensorOIDS {
 		output, err := exec.Command("sysctl", "-n", k).Output()
 		if err != nil {
-			return nil, fmt.Errorf("failed to execute 'sysctl' command: %v", err)
+			continue
 		}
 
 		value, err := refineOutput(output)
 		if err != nil {
-			return nil, fmt.Errorf("failed to execute 'sysctl' command: %v", err)
+			continue
 		}
 
 		measurements = append(measurements, sensorMeasurement{v, value})
-
 	}
+
+	m := collectGPUSensors()
+	measurements = append(measurements, m...)
+
 	return measurements, nil
 
 }


### PR DESCRIPTION
- Fixed issue where failed sysctl would prevent CPU temperature from otherwise showing up
- Fixed issue where Swap was not being displayed with mirrored zfs setup (multiple swap partitions).
- Added nvidia gpu support (based on #156)
- Refactored freebsd_temps.go to be modular.

![2019-07-14-102641_1920x1070_scrot](https://user-images.githubusercontent.com/6548135/61185004-e2c1e400-a621-11e9-8e5a-db34e514623c.png)
