### PR TITLE
Added a color scheme to match Nord.

### DIFF
--- a/colorschemes/nord.go
+++ b/colorschemes/nord.go
@@ -1,0 +1,38 @@
+/*
+	The standard 256 terminal colors are supported.
+
+	-1 = clear
+
+	You can combine a color with 'Bold', 'Underline', or 'Reverse' by using bitwise OR ('|') and the name of the Color.
+	For example, to get Bold red Labels, you would do 'Labels: 2 | Bold'.
+
+	Once you've created a colorscheme, add an entry for it in the `handleColorscheme` function in 'main.go'.
+*/
+
+package colorschemes
+
+var Nord = Colorscheme{
+	Name:   "A Nord Approximation",
+	Author: "@jrswab",
+	Fg:     254, // lightest
+	Bg:     -1,
+
+	BorderLabel: 254,
+	BorderLine:  96, // Purple
+
+	CPULines: []int{4, 3, 2, 1, 5, 6, 7, 8},
+
+	BattLines: []int{4, 3, 2, 1, 5, 6, 7, 8},
+
+	MainMem: 172, // Orange
+	SwapMem: 221, // yellow
+
+	ProcCursor: 31, // blue (nord9)
+
+	Sparkline: 31,
+
+	DiskBar: 254,
+
+	TempLow:  64,  // green
+	TempHigh: 167, // red
+}

--- a/main.go
+++ b/main.go
@@ -135,6 +135,8 @@ func handleColorscheme(cs string) error {
 		colorscheme = colorschemes.Vice
 	case "default-dark":
 		colorscheme = colorschemes.DefaultDark
+	case "nord":
+		colorscheme = colorschemes.Nord
 	default:
 		custom, err := getCustomColorscheme(cs)
 		if err != nil {


### PR DESCRIPTION
This is an approximation since Nord uses HTML color codes that are
outside of the 256 terminal colors.

CPU Lines and BattLines not edited from the default.