### PR TITLE
Added sigterm options to "d" command.

### DIFF
--- a/main.go
+++ b/main.go
@@ -381,7 +381,15 @@ func eventLoop() {
 					ui.Render(proc)
 				case "d":
 					if previousKey == "d" {
-						proc.KillProc()
+						proc.KillProc("SIGTERM")
+					}
+				case "3":
+					if previousKey == "d" {
+						proc.KillProc("SIGQUIT")
+					}
+				case "9":
+					if previousKey == "d" {
+						proc.KillProc("SIGKILL")
 					}
 				case "<Tab>":
 					proc.ToggleShowingGroupedProcs()

--- a/src/widgets/help.go
+++ b/src/widgets/help.go
@@ -22,7 +22,9 @@ Process navigation
 
 Process actions:
   - <Tab>: toggle process grouping
-  - dd: kill selected process or group of processes
+  - dd: kill selected process or group of processes with SIGTERM (15)
+  - d3: kill selected process or group of processes with SIGQUIT (3)
+  - d9: kill selected process or group of processes with SIGKILL (9)
 
 Process sorting
   - c: CPU
@@ -50,7 +52,7 @@ func (self *HelpMenu) Resize(termWidth, termHeight int) {
 		textWidth = maxInt(len(line), textWidth)
 	}
 	textWidth += 2
-	textHeight := 22
+	textHeight := 28
 	x := (termWidth - textWidth) / 2
 	y := (termHeight - textHeight) / 2
 

--- a/src/widgets/proc.go
+++ b/src/widgets/proc.go
@@ -182,14 +182,15 @@ func (self *ProcWidget) ToggleShowingGroupedProcs() {
 	self.convertProcsToTableRows()
 }
 
-// KillProc kills a process or group of processes depending on if we're displaying the processes grouped or not.
-func (self *ProcWidget) KillProc() {
+// KillProc kills a process or group of processes depending on if we're
+// displaying the processes grouped or not.
+func (self *ProcWidget) KillProc(sigName string) {
 	self.SelectedItem = ""
 	command := "kill"
 	if self.UniqueCol == 1 {
 		command = "pkill"
 	}
-	cmd := exec.Command(command, self.Rows[self.SelectedRow][self.UniqueCol])
+	cmd := exec.Command(command, "--signal", sigName, self.Rows[self.SelectedRow][self.UniqueCol])
 	cmd.Start()
 	cmd.Wait()
 }


### PR DESCRIPTION
This should satisfy issue #13 (at least in part). `main.go` now has cases for "dd", "d3", and "d9".

"d3" is "sigquit" and "d9" is "sigkill".

`KillProc()` now takes a string as an arugment to perferm desired kill action using `--signal`.

`help.go` also has been update to reflect the additions.