### PR TITLE
Created the option to add total Mbps as an opiton.

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,6 +48,7 @@ var (
 	battery        = false
 	statusbar      = false
 	netInterface   = w.NET_INTERFACE_ALL
+	bandwidth      uint64
 
 	cpu  *w.CpuWidget
 	batt *w.BatteryWidget
@@ -77,6 +78,7 @@ Options:
   -s, --statusbar       Show a statusbar with the time.
   -b, --battery         Show battery level widget ('minimal' turns off).
   -i, --interface=NAME  Select network interface [default: all].
+  -B, --bandwidth=bits	Specify the number of bits per seconds.
 
 Colorschemes:
   default
@@ -119,6 +121,13 @@ Colorschemes:
 		tempScale = w.Fahrenheit
 	}
 	netInterface, _ = args["--interface"].(string)
+	bandString, _ := args["--bandwidth"].(string)
+	if bandString == "" {
+		return nil
+	}
+	if bandwidth, err = strconv.ParseUint(bandString, 10, 64); err != nil {
+		log.Fatalf("Could not parse Uint from user input: %v", err)
+	}
 
 	return nil
 }
@@ -264,7 +273,7 @@ func initWidgets() {
 		if battery {
 			batt = w.NewBatteryWidget(graphHorizontalScale)
 		}
-		net = w.NewNetWidget(netInterface)
+		net = w.NewNetWidget(netInterface, bandwidth)
 		disk = w.NewDiskWidget()
 		temp = w.NewTempWidget(tempScale)
 	}


### PR DESCRIPTION
When this is used `net.go` will calculate the percentage of bandwidth used and return that an the integer to `self.Lines[#].Data`. If the bandwidth option is not specified it defaults to zero and all functionality is as it was before the option existed.

Usage Examples:
`gotop -B ###`
`gotop --bandwidth ###`

This is in response to issue #80 