### PR TITLE
Add degree symbol to temperature values

### DIFF
--- a/src/widgets/temp.go
+++ b/src/widgets/temp.go
@@ -86,15 +86,15 @@ func (self *TempWidget) Draw(buf *ui.Buffer) {
 		switch self.TempScale {
 		case Fahrenheit:
 			buf.SetString(
-				fmt.Sprintf("%3dF", self.Data[key]),
+				fmt.Sprintf("%3d°F", self.Data[key]),
 				ui.NewStyle(fg),
-				image.Pt(self.Inner.Max.X-4, self.Inner.Min.Y+y),
+				image.Pt(self.Inner.Max.X-5, self.Inner.Min.Y+y),
 			)
 		case Celcius:
 			buf.SetString(
-				fmt.Sprintf("%3dC", self.Data[key]),
+				fmt.Sprintf("%3d°C", self.Data[key]),
 				ui.NewStyle(fg),
-				image.Pt(self.Inner.Max.X-4, self.Inner.Min.Y+y),
+				image.Pt(self.Inner.Max.X-5, self.Inner.Min.Y+y),
 			)
 		}
 	}


### PR DESCRIPTION
Hey,

the correct unit symbols for temperatures are "°C" and "°F" so I added the degree symbol to the format string in `temp.go`. Using the official unicode characters (U+2103  and U+2109) will probably have compatibility issues in some terminals so I opted for their  canonical decomposition.

Best,
Felix